### PR TITLE
Fix sidemenu icon

### DIFF
--- a/lib/open_project/slack/engine.rb
+++ b/lib/open_project/slack/engine.rb
@@ -24,7 +24,7 @@ module OpenProject::Slack
            :slack_settings,
            { controller: '/admin/settings', action: :show_plugin, id: :openproject_slack },
            caption: :label_slack_plugin,
-           icon: 'icon2 icon-slack',
+           icon: 'slack',
            if: ->(*) { User.current.admin? && ::OpenProject::Slack.enabled? }
     end
 


### PR DESCRIPTION
The sidemenu icon for this plugin was broken after the sidemenu was updated as part of the effort to standardize all icons.

Part of https://community.openproject.org/work_packages/48229/activity
Part of https://community.openproject.org/work_packages/47363/activity