### PR TITLE
Fix a couple of bugs.

### DIFF
--- a/app/views/settings/_slack.html.erb
+++ b/app/views/settings/_slack.html.erb
@@ -6,32 +6,35 @@
   end
 %>
 
-<section class="form--section">
-  <input type="hidden" name="settings[enabled]" value="1"/>
+<div id="settings">
+  <%= styled_form_tag({controller: '/admin/settings', action: 'update_plugin' }) do %>
+    <input type="hidden" name="settings[enabled]" value="1"/>
 
-  <div class="form--field">
-    <%= styled_label_tag("settings[webhook_url]", t("slack.default_webhook_url")) %>
-    <div class="form--field-container">
-      <%=
+    <div class="form--field">
+      <%= styled_label_tag("settings[webhook_url]", t("slack.default_webhook_url")) %>
+      <div class="form--field-container">
+        <%=
         styled_text_field_tag(
           "settings[webhook_url]",
           Setting.plugin_openproject_slack["webhook_url"],
-          container_class: '-xwide'
+          container_class: '-xwide',
+          type: 'url',
+          pattern: "[ -~]*",
+          title: t("slack.only_ascii_chars_url"),
         )
-      %>
+        %>
+      </div>
     </div>
-  </div>
 
-  <span class="form--field-instructions">
-    <%# Creates the custom field if not yet present. %>
-    <% custom_field = OpenProject::Slack.project_custom_field %>
-    <% edit_url = edit_admin_settings_project_custom_field_path custom_field %>
-    <%=
-      t(
+    <span class="form--field-instructions">
+      <%# Creates the custom field if not yet present. %>
+      <% custom_field = OpenProject::Slack.project_custom_field %>
+      <%= t(
         "slack.per_project_instructions_html",
-        custom_field_url: edit_url,
+        custom_field_url: edit_admin_settings_project_custom_field_path(custom_field),
         custom_field_name: custom_field.name
-      )
-    %>
-  </span>
-</section>
+      ) %>
+    </span>
+    <%= styled_submit_tag t(:button_apply), class: '-primary' %>
+  <% end %>
+</div>

--- a/app/workers/slack_notification_job.rb
+++ b/app/workers/slack_notification_job.rb
@@ -38,6 +38,13 @@ class SlackNotificationJob < ApplicationJob
       return
     end
 
+    # prevent https://community.openproject.org/work_packages/56435/activity
+    if !URI(webhook_url).respond_to?(:request_uri)
+      OpenProject.logger.warn("Slack webhook URL is misconfigured: #{webhook_url}")
+
+      return
+    end
+
     notifier(webhook_url: webhook_url).post params
   rescue Slack::Notifier::APIError => e
     OpenProject.logger.warn "Error posting to Slack: #{e.message}"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -7,6 +7,7 @@ en:
       <a href="%{custom_field_url}">%{custom_field_name}</a> custom field
       which can be set in the project settings. You must not rename or delete
       the custom field. If you do, a new one will be created automatically.
+    only_ascii_chars_url: "Only ASCII characters are allowed in URL"
   field_type: Type
   field_project: Project
   field_subject: Subject

--- a/lib/open_project/slack.rb
+++ b/lib/open_project/slack.rb
@@ -52,14 +52,14 @@ module OpenProject
         {
           name: webhook_url_label,
           type: 'ProjectCustomField',
-          field_format: 'string',
+          field_format: 'link',
+          regex: "^[ -~]*$", # only ASCII chars, because later URI.parse will not accept it
           custom_field_section_id: CustomFieldSection.first.id
         }
       end
 
       def project_custom_field
-        @project_custom_field ||= CustomField.find_by(name: webhook_url_label) ||
-                                  CustomField.create(project_custom_field_params)
+        CustomField.find_by(name: webhook_url_label) || CustomField.create(project_custom_field_params)
       end
     end
   end

--- a/lib/open_project/slack/version.rb
+++ b/lib/open_project/slack/version.rb
@@ -1,5 +1,5 @@
 module OpenProject
   module Slack
-    VERSION = "14.0.1"
+    VERSION = "14.4.0"
   end
 end


### PR DESCRIPTION
https://community.openproject.org/wp/56435
https://community.openproject.org/wp/56439
https://community.openproject.org/wp/56813

- Add *Apply* button to Slack plugin settings form
- Add validation for webhook_url.
  - Use html input type url and only ASCII regex on administration level setting
  - Use custom field type url and only ASCII regex on project level setting
- Remove caching project_custome_field instance to class instance
  variable
- Prevent background job failure. Log misconfigured webhook_url instead.
