### PR TITLE
update slack plugin to work with Openproject 15.1

### DIFF
--- a/app/views/settings/_slack.html.erb
+++ b/app/views/settings/_slack.html.erb
@@ -1,40 +1,29 @@
-<%=
-  render Primer::OpenProject::PageHeader.new do |header|
-    header.with_title { t(:label_slack_plugin) }
-    header.with_breadcrumbs([{ href: admin_index_path, text: t("label_administration") },
-                             t(:label_slack_plugin)])
-  end
-%>
-
 <div id="settings">
-  <%= styled_form_tag({controller: '/admin/settings', action: 'update_plugin' }) do %>
-    <input type="hidden" name="settings[enabled]" value="1"/>
+  <input type="hidden" name="settings[enabled]" value="1"/>
 
-    <div class="form--field">
-      <%= styled_label_tag("settings[webhook_url]", t("slack.default_webhook_url")) %>
-      <div class="form--field-container">
-        <%=
-        styled_text_field_tag(
-          "settings[webhook_url]",
-          Setting.plugin_openproject_slack["webhook_url"],
-          container_class: '-xwide',
-          type: 'url',
-          pattern: "[ -~]*",
-          title: t("slack.only_ascii_chars_url"),
-        )
-        %>
-      </div>
+  <div class="form--field">
+    <%= styled_label_tag("settings[webhook_url]", t("slack.default_webhook_url")) %>
+    <div class="form--field-container">
+      <%=
+      styled_text_field_tag(
+        "settings[webhook_url]",
+        Setting.plugin_openproject_slack["webhook_url"],
+        container_class: '-xwide',
+        type: 'url',
+        pattern: "[ -~]*",
+        title: t("slack.only_ascii_chars_url"),
+      )
+      %>
     </div>
+  </div>
 
-    <span class="form--field-instructions">
-      <%# Creates the custom field if not yet present. %>
-      <% custom_field = OpenProject::Slack.project_custom_field %>
-      <%= t(
-        "slack.per_project_instructions_html",
-        custom_field_url: edit_admin_settings_project_custom_field_path(custom_field),
-        custom_field_name: custom_field.name
-      ) %>
-    </span>
-    <%= styled_submit_tag t(:button_apply), class: '-primary' %>
-  <% end %>
+  <span class="form--field-instructions">
+    <%# Creates the custom field if not yet present. %>
+    <% custom_field = OpenProject::Slack.project_custom_field %>
+    <%= t(
+      "slack.per_project_instructions_html",
+      custom_field_url: edit_admin_settings_project_custom_field_path(custom_field),
+      custom_field_name: custom_field.name
+    ) %>
+  </span>
 </div>

--- a/app/views/settings/_slack.html.erb
+++ b/app/views/settings/_slack.html.erb
@@ -1,29 +1,27 @@
-<div id="settings">
-  <input type="hidden" name="settings[enabled]" value="1"/>
+<input type="hidden" name="settings[enabled]" value="1"/>
 
-  <div class="form--field">
-    <%= styled_label_tag("settings[webhook_url]", t("slack.default_webhook_url")) %>
-    <div class="form--field-container">
-      <%=
-      styled_text_field_tag(
-        "settings[webhook_url]",
-        Setting.plugin_openproject_slack["webhook_url"],
-        container_class: '-xwide',
-        type: 'url',
-        pattern: "[ -~]*",
-        title: t("slack.only_ascii_chars_url"),
-      )
-      %>
-    </div>
+<div class="form--field">
+  <%= styled_label_tag("settings[webhook_url]", t("slack.default_webhook_url")) %>
+  <div class="form--field-container">
+    <%=
+    styled_text_field_tag(
+      "settings[webhook_url]",
+      Setting.plugin_openproject_slack["webhook_url"],
+      container_class: '-xwide',
+      type: 'url',
+      pattern: "[ -~]*",
+      title: t("slack.only_ascii_chars_url"),
+    )
+    %>
   </div>
-
-  <span class="form--field-instructions">
-    <%# Creates the custom field if not yet present. %>
-    <% custom_field = OpenProject::Slack.project_custom_field %>
-    <%= t(
-      "slack.per_project_instructions_html",
-      custom_field_url: edit_admin_settings_project_custom_field_path(custom_field),
-      custom_field_name: custom_field.name
-    ) %>
-  </span>
 </div>
+
+<span class="form--field-instructions">
+  <%# Creates the custom field if not yet present. %>
+  <% custom_field = OpenProject::Slack.project_custom_field %>
+  <%= t(
+    "slack.per_project_instructions_html",
+    custom_field_url: edit_admin_settings_project_custom_field_path(custom_field),
+    custom_field_name: custom_field.name
+  ) %>
+</span>

--- a/lib/open_project/slack.rb
+++ b/lib/open_project/slack.rb
@@ -53,7 +53,7 @@ module OpenProject
           name: webhook_url_label,
           type: 'ProjectCustomField',
           field_format: 'link',
-          regex: "^[ -~]*$", # only ASCII chars, because later URI.parse will not accept it
+          regexp: "^[ -~]*$", # only ASCII chars, because later URI.parse will not accept it
           custom_field_section_id: CustomFieldSection.first.id
         }
       end

--- a/lib/open_project/slack/hook_listener.rb
+++ b/lib/open_project/slack/hook_listener.rb
@@ -12,15 +12,16 @@ class OpenProject::Slack::HookListener < OpenProject::Hook::Listener
     return unless webhook_url.present?
 
     page = context[:page]
-    user = page.content.author
+    user = page.author
     project_url = "<#{object_url project}|#{escape project}>"
     page_url = "<#{object_url page}|#{page.title}>"
     message = "[#{project_url}] #{page_url} updated by *#{user}*"
     attachment = nil
+    comments = page.journals.last.notes
 
-    if page.content.comments.present?
+    if comments.present?
       attachment = {}
-      attachment[:text] = "#{escape page.content.comments}"
+      attachment[:text] = "#{escape comments}"
     end
 
     OpenProject::Slack::Notifier.say(

--- a/spec/controllers/wiki_controller_spec.rb
+++ b/spec/controllers/wiki_controller_spec.rb
@@ -28,9 +28,9 @@
 
 require 'spec_helper'
 
-describe WikiController, type: :controller do
-  let(:protocol) { "https" }
-  let(:host_name) { "test.openproject.com" }
+RSpec.describe WikiController, type: :controller do
+  let(:protocol) { "http" }
+  let(:host_name) { "test.host" }
 
   before do
     Role.delete_all # removing me makes us faster
@@ -38,7 +38,7 @@ describe WikiController, type: :controller do
     I18n.locale = :en
   end
 
-  describe 'actions', with_settings: { host_name: "test.openproject.com", protocol: "https" } do
+  describe 'actions', with_settings: { host_name: "test.host" } do
     let(:page_title) { "abc" }
 
     let(:expected_text) do
@@ -59,14 +59,7 @@ describe WikiController, type: :controller do
       @project.reload # to get the wiki into the proxy
 
       # creating pages
-      @existing_page = FactoryBot.create(
-        :wiki_page, wiki_id: @project.wiki.id, title: 'ExistingPage'
-      )
-
-      # creating page contents
-      FactoryBot.create(
-        :wiki_content, page_id: @existing_page.id, author_id: @user.id
-      )
+      @existing_page = create :wiki_page, wiki: @project.wiki, author: @user, title: 'ExistingPage'
 
       allow(::OpenProject::Slack).to receive(:default_webhook_url).and_return("https://foo.bar.com/webhook/42")
 
@@ -80,7 +73,10 @@ describe WikiController, type: :controller do
         post 'create',
              params: {
                project_id: @project,
-               content: { text: 'h1. abc', page: { title: 'abc' } }
+               page: {
+                 title: 'abc',
+                 text: 'h1. abc'
+               }
              }
 
         expect(response).to redirect_to action: 'show', project_id: @project, id: page_title
@@ -95,7 +91,10 @@ describe WikiController, type: :controller do
              params: {
                id: page_title,
                project_id: @project,
-               content: { text: 'h1. abc', page: { title: 'ExistingPage' } }
+               page: {
+                 title: 'ExistingPage',
+                 text: 'h1. abc'
+               }
              }
 
         expect(response).to redirect_to action: 'show', project_id: @project, id: @existing_page.slug

--- a/spec/lib/notifier_spec.rb
+++ b/spec/lib/notifier_spec.rb
@@ -1,16 +1,6 @@
 require 'spec_helper'
 
-describe OpenProject::Slack::Notifier do
-  context 'when slack url is not specified' do
-    before do
-      Setting.plugin_openproject_slack['webhook_url'] = nil
-    end
-
-    it 'should raise error' do
-      expect { OpenProject::Slack::Notifier.say text: "test" }.to raise_error(URI::InvalidURIError, /bad URI/i)
-    end
-  end
-
+RSpec.describe OpenProject::Slack::Notifier do
   describe '#say' do
     let(:url) { 'https://hooks.slack.com/services/foo' }
     let(:message) { 'message' }
@@ -21,26 +11,15 @@ describe OpenProject::Slack::Notifier do
       end
     end
 
-    before do
-      Setting.plugin_openproject_slack['webhook_url'] = url
-    end
+    let(:webhook_url) { 'https://hooks.slack.com/services/bar' }
 
-    it 'should use the URL from the settings' do
-      expect(::Slack::Notifier).to receive(:new).with(url).and_return(dummy)
-      expect(dummy).to receive(:post).with text: message, link_names: 1
+    it 'should use the override URL' do
+      expect(::Slack::Notifier).to receive(:new).with(webhook_url).and_return(dummy)
+      expect(dummy).to receive(:post).with({ text: message, link_names: 1 })
 
-      OpenProject::Slack::Notifier.say text: message
-    end
+      OpenProject::Slack::Notifier.say text: message, webhook_url: webhook_url
 
-    context 'with URL overriden' do
-      let(:override_url) { 'https://hooks.slack.com/services/bar' }
-
-      it 'should use the override URL' do
-        expect(::Slack::Notifier).to receive(:new).with(override_url).and_return(dummy)
-        expect(dummy).to receive(:post).with text: message, link_names: 1
-
-        OpenProject::Slack::Notifier.say text: message, webhook_url: override_url
-      end
+      perform_enqueued_jobs
     end
   end
 end

--- a/spec/models/work_package_spec.rb
+++ b/spec/models/work_package_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'slack-notifier'
 
-describe WorkPackage, with_settings: { "host_name" => "test.openproject.com", "protocol" => "https" } do
+RSpec.describe WorkPackage, with_settings: { "host_name" => "test.openproject.com" } do
   let(:user) { FactoryBot.create :admin, firstname: "Peter", lastname: "Putzig" }
   let(:project) { FactoryBot.create :project_with_types, name: "Parts", identifier: "parts" }
 
@@ -23,7 +23,7 @@ describe WorkPackage, with_settings: { "host_name" => "test.openproject.com", "p
 
     let(:update_service) { WorkPackages::UpdateService.new user: user, model: work_package }
     let(:expected_text) do
-      "[<https://test.openproject.com/projects/#{project.identifier}|#{project.name}>] #{user.name} updated <https://test.openproject.com/work_packages/#{work_package.id}|#{work_package.type.name} ##{work_package.id}: #{work_package.subject}>"
+      "[<http://test.openproject.com/projects/#{project.identifier}|#{project.name}>] #{user.name} updated <http://test.openproject.com/work_packages/#{work_package.id}|#{work_package.type.name} ##{work_package.id}: #{work_package.subject}>"
     end
 
     before do
@@ -52,7 +52,7 @@ describe WorkPackage, with_settings: { "host_name" => "test.openproject.com", "p
     let(:description) { "Tires should be round" }
 
     before do
-      allow(::OpenProject::Slack).to receive(:default_webhook_url).and_return("https://foo.bar.com/webhook/42")
+      allow(::OpenProject::Slack).to receive(:default_webhook_url).and_return("http://foo.bar.com/webhook/42")
     end
 
     let(:create_service) { WorkPackages::CreateService.new user: user }
@@ -66,7 +66,7 @@ describe WorkPackage, with_settings: { "host_name" => "test.openproject.com", "p
 
         text = opts[:text]
 
-        expect(text).to start_with("[<https://test.openproject.com/projects/#{project.identifier}|#{project.name}>] #{user.name} created <https://test.openproject.com/work_packages/")
+        expect(text).to start_with("[<http://test.openproject.com/projects/#{project.identifier}|#{project.name}>] #{user.name} created <http://test.openproject.com/work_packages/")
         expect(text).to match /.*\/work_packages\/\d+\|#{type.name} #\d+: #{subject}>$/
       end
     end


### PR DESCRIPTION
WP [#59943](https://community.openproject.org/projects/openproject/work_packages/59943/activity)

The CI workflow for tests is still missing for this plugin.
Test locally by adding the following `Gemfile.plugins` file.

```ruby
group :opf_plugins do
  gem "openproject-slack", path: ".../openproject-slack"
end
```

And running

```bash
RAILS_ENV=test bundle exec rspec .../openproject-slack/spec
```